### PR TITLE
Bump API to include time tracking custom property name

### DIFF
--- a/dart/generated/models/TaskTimeTrackingCreate.ts
+++ b/dart/generated/models/TaskTimeTrackingCreate.ts
@@ -15,4 +15,8 @@ export type TaskTimeTrackingCreate = {
    * The end timestamp for the tracked time entry in ISO 8601 format. Must be after the start time.
    */
   finishedAt: string;
+  /**
+   * The time tracking custom property name listed in config customProperties. Must be a time tracking type. If omitted, defaults to the main time tracking property.
+   */
+  customPropertyName?: string | null;
 };

--- a/dart/generated/services/DocService.ts
+++ b/dart/generated/services/DocService.ts
@@ -123,7 +123,7 @@ export class DocService {
      */
     limit?: number;
     /**
-     * Controls whether default filters and sorting are applied when false (default) or no defaults are applied when true. Explicit filters or sorting always override defaults.
+     * Whether default filters and sorting are applied when false (default) or no defaults are applied when true. Explicit filters or sorting always override defaults.
      */
     noDefaults?: boolean;
     /**

--- a/dart/generated/services/TaskService.ts
+++ b/dart/generated/services/TaskService.ts
@@ -205,7 +205,7 @@ export class TaskService {
      */
     limit?: number;
     /**
-     * Controls whether default filters and sorting are applied when false (default) or no defaults are applied when true. Explicit filters or sorting always override defaults.
+     * Whether default filters and sorting are applied when false (default) or no defaults are applied when true. Explicit filters or sorting always override defaults.
      */
     noDefaults?: boolean;
     /**


### PR DESCRIPTION
# Add support for custom property time tracking

This PR adds the ability to specify a custom property name when creating time tracking entries. The `TaskTimeTrackingCreate` type now includes an optional `customPropertyName` field that allows targeting a specific time tracking property.

Additionally, the PR improves parameter documentation in both `DocService` and `TaskService` by making the `noDefaults` parameter description more concise.